### PR TITLE
feat: Add unit tests for poses.py render_pose_image() and error paths

### DIFF
--- a/src/animeforge/pipeline/poses.py
+++ b/src/animeforge/pipeline/poses.py
@@ -98,7 +98,7 @@ def interpolate_poses(
 
     for i in range(target_frames):
         # Map output frame index to a floating-point source index.
-        t = i / max(target_frames - 1, 1) * max(n_src - 1, 1)
+        t = i / max(target_frames - 1, 1) * (n_src - 1)
         idx_lo = int(t)
         idx_hi = min(idx_lo + 1, n_src - 1)
         alpha = t - idx_lo

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,6 +8,7 @@ from PIL import Image
 
 from animeforge.models import AnimationDef, Character, Rect, Scene, Zone
 from animeforge.models.enums import TimeOfDay, Weather
+from animeforge.models.pose import PoseFrame, PoseKeypoints, PoseSequence
 from animeforge.pipeline.assembly import AssemblyError, assemble_sprite_sheet
 from animeforge.pipeline.consistency import (
     build_character_prompt,
@@ -20,7 +21,7 @@ from animeforge.pipeline.effect_gen import (
     generate_sakura_sprites,
     generate_snow_sprites,
 )
-from animeforge.pipeline.poses import interpolate_poses, load_pose_sequence
+from animeforge.pipeline.poses import interpolate_poses, load_pose_sequence, render_pose_image
 
 
 def test_build_scene_prompt():
@@ -154,3 +155,50 @@ def test_assemble_sprite_sheet_missing_file_raises_assembly_error(tmp_path: Path
 
     with pytest.raises(AssemblyError, match="Frame 0"):
         assemble_sprite_sheet([missing], tmp_path / "sheet.png", frame_size=(32, 32))
+
+
+def test_interpolate_poses_empty_sequence_raises():
+    seq = PoseSequence(name="empty", frames=[])
+    with pytest.raises(ValueError, match="has no frames"):
+        interpolate_poses(seq, 5)
+
+
+def test_interpolate_poses_zero_target_raises():
+    seq = PoseSequence(name="one", frames=[PoseFrame(keypoints=PoseKeypoints())])
+    with pytest.raises(ValueError, match="target_frames must be positive"):
+        interpolate_poses(seq, 0)
+    with pytest.raises(ValueError, match="target_frames must be positive"):
+        interpolate_poses(seq, -1)
+
+
+def test_interpolate_poses_single_source_frame():
+    kp = PoseKeypoints(nose=[0.3, 0.2, 1.0])
+    seq = PoseSequence(name="single", frames=[PoseFrame(keypoints=kp)])
+    result = interpolate_poses(seq, 5)
+    assert len(result) == 5
+    for frame_kp in result:
+        assert frame_kp.nose == pytest.approx([0.3, 0.2, 1.0])
+
+
+def test_render_pose_image_creates_file(tmp_path: Path):
+    from PIL import Image as PILImage
+
+    kp = PoseKeypoints()
+    out = tmp_path / "pose.png"
+    returned = render_pose_image(kp, out)
+    assert returned == out
+    assert out.exists()
+    assert out.suffix == ".png"
+    img = PILImage.open(out)
+    img.load()
+    assert img.format == "PNG"
+
+
+def test_render_pose_image_dimensions(tmp_path: Path):
+    from PIL import Image as PILImage
+
+    kp = PoseKeypoints()
+    out = tmp_path / "pose.png"
+    render_pose_image(kp, out, width=256, height=128)
+    img = PILImage.open(out)
+    assert img.size == (256, 128)


### PR DESCRIPTION
Resolves #43

## Summary
- Add five new tests to `test_pipeline.py` covering `render_pose_image()` and `interpolate_poses()` error paths
- Fix a bug in `interpolate_poses()` where single-source sequences caused an IndexError

Rebased from original PR #45 (which was closed).

## Test Plan
- [x] All 186 tests pass locally
- [x] `ruff check` clean
- [x] New tests cover: render_pose_image file creation, custom dimensions, empty sequence ValueError, zero/negative target ValueError, single-frame edge case

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>