### PR TITLE
test: export preview tests

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,7 +8,7 @@ import pytest
 
 from animeforge.models import ExportConfig, Project
 from animeforge.pipeline import export as export_module
-from animeforge.pipeline.export import ExportError, export_project
+from animeforge.pipeline.export import ExportError, _generate_preview, export_project
 
 
 @pytest.fixture
@@ -156,3 +156,89 @@ def test_css_template_syntax_error_propagates(
     config = ExportConfig(output_dir=tmp_path / "export_out", image_format="png")
     with pytest.raises(jinja2.TemplateSyntaxError):
         export_project(_populated_project, config)
+
+
+# ---------------------------------------------------------------------------
+# _generate_preview() tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_preview_writes_jpeg(tmp_path: Path):
+    """Happy path: a valid PNG in bg_dir produces a preview.jpg."""
+    from PIL import Image
+
+    bg_dir = tmp_path / "backgrounds"
+    bg_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    img = Image.new("RGB", (100, 100), (255, 0, 0))
+    img.save(bg_dir / "bg.png")
+
+    _generate_preview(bg_dir, out_dir)
+
+    preview = out_dir / "preview.jpg"
+    assert preview.exists()
+    assert preview.stat().st_size > 0
+
+    result = Image.open(preview)
+    assert result.format == "JPEG"
+
+
+def test_generate_preview_no_candidates(tmp_path: Path):
+    """Empty bg_dir should produce no preview and raise no exception."""
+    bg_dir = tmp_path / "backgrounds"
+    bg_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    _generate_preview(bg_dir, out_dir)
+
+    assert not (out_dir / "preview.jpg").exists()
+
+
+def test_generate_preview_corrupt_image(tmp_path: Path):
+    """A zero-byte file should be handled gracefully (no exception raised)."""
+    bg_dir = tmp_path / "backgrounds"
+    bg_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    (bg_dir / "bg.png").write_bytes(b"")
+
+    _generate_preview(bg_dir, out_dir)
+
+    assert not (out_dir / "preview.jpg").exists()
+
+
+# ---------------------------------------------------------------------------
+# TemplateNotFound fallback test
+# ---------------------------------------------------------------------------
+
+
+def test_export_css_template_not_found_fallback(
+    _populated_project: Project,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """TemplateNotFound for scene.css.jinja2 should trigger _fallback_css()."""
+    original_env_class = export_module.Environment
+
+    class _MissingCSSEnv(original_env_class):
+        def get_template(self, name, *a, **kw):
+            if name == "scene.css.jinja2":
+                raise jinja2.TemplateNotFound("scene.css.jinja2")
+            return super().get_template(name, *a, **kw)
+
+    monkeypatch.setattr(export_module, "Environment", _MissingCSSEnv)
+
+    config = ExportConfig(output_dir=tmp_path / "export_out", image_format="png")
+    out = export_project(_populated_project, config)
+
+    css_path = out / "scene.css"
+    assert css_path.exists()
+
+    css_content = css_path.read_text()
+    assert ".animeforge-scene" in css_content
+    assert f"{_populated_project.scene.width}px" in css_content
+    assert f"{_populated_project.scene.height}px" in css_content


### PR DESCRIPTION
Closes #35

## Summary
- Add `test_generate_preview_writes_jpeg` -- happy path, valid PNG in bg_dir produces a preview.jpg
- Add `test_generate_preview_no_candidates` -- empty directory produces no preview, no exception
- Add `test_generate_preview_corrupt_image` -- zero-byte file handled gracefully (no exception)
- Add `test_export_css_template_not_found_fallback` -- TemplateNotFound triggers _fallback_css() with correct CSS

## Test plan
- [x] `uv run ruff check tests/ --fix` passes
- [x] `uv run ruff format tests/` no changes
- [x] `uv run python -m pytest tests/test_export.py -v` -- 12/12 pass
- [x] `uv run python -m pytest tests/ -v` -- all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)